### PR TITLE
Optimize the seek method

### DIFF
--- a/disk_buffer_reader.go
+++ b/disk_buffer_reader.go
@@ -98,44 +98,46 @@ func (dbr *DiskBufferReader) Reset() error {
 
 // Seek sets the offset for the next Read or Write to offset.
 func (dbr *DiskBufferReader) Seek(offset int64, whence int) (int64, error) {
+	newIndex := dbr.index
+
 	switch whence {
 	case io.SeekStart:
-		switch {
-		case offset < 0:
-			return 0, fmt.Errorf("can not seek to before start of reader")
-		case offset > dbr.bytesRead:
-			trashBytes := make([]byte, offset-dbr.bytesRead)
-			dbr.Read(trashBytes)
-		}
-		dbr.index = offset
+		newIndex = offset
 	case io.SeekCurrent:
-		switch {
-		case dbr.index+offset < 0:
-			return 0, fmt.Errorf("can not seek to before start of reader")
-		case offset > 0:
-			trashBytes := make([]byte, offset)
-			dbr.Read(trashBytes)
-		}
-		dbr.index += offset
+		newIndex += offset
 	case io.SeekEnd:
-		trashBytes := make([]byte, 1024)
-		for {
-			_, err := dbr.Read(trashBytes)
-			if err != nil {
-				if errors.Is(err, io.EOF) {
-					break
-				}
-				return dbr.index, err
-			}
-		}
-		if dbr.index+offset < 0 {
-			return 0, fmt.Errorf("can not seek to before start of reader")
-		}
-		dbr.index += offset
-		return dbr.index, nil
+		newIndex = dbr.bytesRead + offset
 	}
 
-	return dbr.index, nil
+	if newIndex < 0 {
+		return 0, fmt.Errorf("can not seek to before start of reader")
+	}
+
+	// If seeking past the bytes read and recording is on, fill the gap by reading the necessary bytes.
+	if newIndex > dbr.bytesRead && dbr.recording {
+		_, err := dbr.tmpFile.Seek(0, io.SeekEnd)
+		if err != nil {
+			return 0, err
+		}
+
+		bytesToRead := int(newIndex - dbr.bytesRead)
+		trashBytes := make([]byte, bytesToRead)
+
+		n, err := dbr.reader.Read(trashBytes)
+		if err != nil && !errors.Is(err, io.EOF) {
+			return 0, err
+		}
+
+		m, err := dbr.tmpFile.Write(trashBytes[:n])
+		if err != nil {
+			return 0, err
+		}
+
+		dbr.bytesRead += int64(m)
+	}
+
+	dbr.index = newIndex
+	return newIndex, nil
 }
 
 // ReadAt reads len(p) bytes into p starting at offset off in the underlying input source.

--- a/disk_buffer_reader_test.go
+++ b/disk_buffer_reader_test.go
@@ -180,3 +180,35 @@ func TestReadAllLarge(t *testing.T) {
 		t.Fatalf("Unexpected error. Got: %s, expected: %s", testErr, baseErr)
 	}
 }
+
+func BenchmarkSeek(b *testing.B) {
+	// Use a fixed data source for consistent benchmarking
+	data := make([]byte, 100000) // Example: 100KB of data
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+
+	// Create a bytes buffer from the data
+	tmpReader := bytes.NewBuffer(data)
+
+	// Create a DiskBufferReader instance
+	dbr, err := New(tmpReader)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer dbr.Close()
+
+	// Parameters for Seek method
+	whenceOptions := []int{io.SeekStart, io.SeekCurrent, io.SeekEnd}
+	offset := int64(100) // Example offset value
+
+	// Start the benchmark loop
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		whence := whenceOptions[i%len(whenceOptions)] // Vary whence to cover different cases
+		_, err := dbr.Seek(offset, whence)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/disk_buffer_reader_test.go
+++ b/disk_buffer_reader_test.go
@@ -182,27 +182,23 @@ func TestReadAllLarge(t *testing.T) {
 }
 
 func BenchmarkSeek(b *testing.B) {
-	// Use a fixed data source for consistent benchmarking
+	// Use a fixed data source for consistent benchmarking.
 	data := make([]byte, 100000) // Example: 100KB of data
 	for i := range data {
 		data[i] = byte(i % 256)
 	}
 
-	// Create a bytes buffer from the data
 	tmpReader := bytes.NewBuffer(data)
 
-	// Create a DiskBufferReader instance
 	dbr, err := New(tmpReader)
 	if err != nil {
 		b.Fatal(err)
 	}
 	defer dbr.Close()
 
-	// Parameters for Seek method
 	whenceOptions := []int{io.SeekStart, io.SeekCurrent, io.SeekEnd}
 	offset := int64(100) // Example offset value
 
-	// Start the benchmark loop
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		whence := whenceOptions[i%len(whenceOptions)] // Vary whence to cover different cases


### PR DESCRIPTION
I believe these changes should not effect any existing functionality, but should give us a little extra perf gains.

- Consolidated the logic for updating the index based on whence at the beginning of the method. This allows us to handle all three seek types uniformly.
- Removed the logic for reading "trash" bytes in small increments. Instead, if the new index is past the bytes read, we calculate the exact number of bytes needed and read them in one go. This should be more efficient, especially for large offsets.
- Ensured that all error handling is in place, and the behavior remains consistent with the original implementation where needed.

![Screenshot 2023-08-21 at 11 05 53 AM](https://github.com/bill-rich/disk-buffer-reader/assets/21311841/0f8c825e-c327-4f0d-8f19-98c1bf728d9c)
